### PR TITLE
Rename push/pop to affix/split [BREAKING CHANGE]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arraytools"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2018"
 
 license = "MIT/Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ How to use with cargo:
 
 ```toml
 [dependencies]
-arraytools = "0.1"
+arraytools = "0.2"
 ```
 
 How to use in your 2018-edition crate:


### PR DESCRIPTION
Your thoughts welcome!

Slices have `split_first`, so it makes sense to copy that.  But what antonym fits well?