### PR TITLE
add support for const generics through feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,12 @@ description = "A variety of helpful methods for working with fixed-size arrays."
 keywords = ["array", "no_std"]
 categories = ["no-std", "rust-patterns"]
 
+[features]
+#default = ["const-generics"]
+const-generics = ["array-init"]
+
 [dependencies]
-# none!
+array-init = {version = "2.0.0", optional=true}
 
 [badges]
 travis-ci = { repository = "scottmcm/arraytools" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["array", "no_std"]
 categories = ["no-std", "rust-patterns"]
 
 [features]
-#default = ["const-generics"]
 const-generics = ["array-init"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -57,3 +57,27 @@ use arraytools::ArrayTools;
 ```
 
 Because this needs non-`Copy` slice patterns, it needs at least **Rust 1.31.0**.
+
+
+## Const generics
+
+Some features in this crate also work for `const-generic` arrays. For this, you will need at least
+rust version **1.51**. To enable this, use the `const-generics` feature. The api is exactly the same except:
+
+* `push_front`, `push_back`, `pop_front`, `pop_back`, `to_tuple` and `from_tuple` can only be used on arrays of which the length is *not* specified by const generics and are shorter than 32 elements 
+* methods on arrays which take closures allways take `FnMut`, where in the version without `const-generics` they could take `FnOnce` when the size was known to be 1 or 0.
+
+Using the `const-generics` feature, the following code will work:
+
+```rust
+use arraytools::ArrayTools;
+
+fn add_ten<const N: usize>(arr: [usize; N]) -> [usize; N] {
+    arr.map(|i| i + 10)
+}
+
+assert_eq!(add_ten([1, 2, 3]), [11, 12, 13]);
+assert_eq!(add_ten([1, 2, 3, 4, 5]), [11, 12, 13, 14, 15]);
+assert_eq!(add_ten([1, 2, 3, 4, 5, 6, 7]), [11, 12, 13, 14, 15, 16, 17]);
+
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,32 @@
 //! }
 //! ```
 //!
+//!
+//! ## Const generics
+//!
+//! Some features in this crate also work for `const-generic` arrays. For this, you will need at least
+//! rust version **1.51**. To enable this, use the `const-generics` feature. The api is exactly the same except:
+//!
+//! * `push_front`, `push_back`, `pop_front`, `pop_back`, `to_tuple` and `from_tuple` can only be used on arrays of which the length is *not* specified by const generics and are shorter than 32 elements
+//! * methods on arrays which take closures allways take `FnMut`, where in the version without `const-generics` they could take `FnOnce` when the size was known to be 1 or 0.
+//!
+//! Using the `const-generics` feature, the following code will work:
+//!
+//! ```rust
+//! # #[cfg(feature = "const-generics")]
+//! # {
+//! use arraytools::ArrayTools;
+//!
+//! fn add_ten<const N: usize>(arr: [usize; N]) -> [usize; N] {
+//!     arr.map(|i| i + 10)
+//! }
+//!
+//! assert_eq!(add_ten([1, 2, 3]), [11, 12, 13]);
+//! assert_eq!(add_ten([1, 2, 3, 4, 5]), [11, 12, 13, 14, 15]);
+//! assert_eq!(add_ten([1, 2, 3, 4, 5, 6, 7]), [11, 12, 13, 14, 15, 16, 17]);
+//! # }
+//! ```
+//!
 
 
 use self::traits::*;


### PR DESCRIPTION
# Motiviation

In some code I'm working on, being able to use map on arrays with lengths specified through const generics would be a great thing to have. However, this code only works for arrays of a few specified lengths. I could publish a new crate supporting this, but most of the functionality is already included in this crate. So I decided to modify it.

# Problems

* Push and Pop cannot work using const generics, because currently Rust does not support doing math with const generic.
* To and From tuple cannot work using const generics, their type is generated using macros
* In some cases, FnOnce is taken in without const generics. This distinction is really hard to make currently because you cannot put bounds on const generics. Specialization would also fix this.
* In some cases (like with repeat), the last element is not cloned but moved. This cannot work with const generics without specializations or bounds (same as previous point)
* (some) Unsafe code is required (!)

# Solutions
The implementation proposed in this pull request makes some compromises to still make everything work

* The implementation using const generic is feature-gated.
* push and pop are only implemented when the length is known and smaller than 32. This is still done with macros. This way push and pop won't work with truly const generic arrays, but they will work in situations where they previously worked.
* The same is done with to and from tuple
* In the const generic version, FnMut is always taken, as it imposes as few restrictions as possible, though this is obviously not ideal.
* All elements are cloned. The last element is not moved. I made this change as well for the regular non-const generic version as I think this feature doesn't add much. I clone more or less does not make much of a difference. In fact, rust might still be able to optimize this away. If this is not what you like however, the cloning/moving could be feature gated behind the const-generics feature. I chose not to do this so all tests are the same between the two implementations and the implementations are more consistent. Our opinions may differ on this one
* The unsafe code required is just an optimization, to avoid needing to initialize arrays twice. To avoid this, MaybeUninit can be used. MaybeUninit *can* be guaranteed to be safe. To avoid needing to prove this ourselves, I added the `array_init` dependency which does this for us. This dependency is gated behind the const-generics feature.


All tests pass on both versions of arraytools. Please let me know what you think of this! 




